### PR TITLE
fixed authorisation check logic

### DIFF
--- a/server/modules/authorisation/verifyMaciToken.js
+++ b/server/modules/authorisation/verifyMaciToken.js
@@ -4,48 +4,36 @@ function verifyMaciToken(req, res, next) {
   const requestURL = req.url;
   console.log(requestURL);
 
-  const publicURLs = [
-    "/slack-sign-in",
-    "/slack/oauth_redirect",
-    "/songs",
-    "/songs/random",
-    "/search",
-  ];
-
-  // const basicURLs = ["/songs/add"];
-  // const adminURLs = ["/update"];
-  //regex patterns to check if url starts with /update or /songs/add. regex is used so that if a / or ? is included at the end of the url, it will still be blocked unlike using array.includes where the url must match exactly
+  // //regex patterns to check if url starts with /update or /songs/add. regex is used so that if a / or ? is included at the end of the url, it will still be blocked unlike using array.includes where the url must match exactly
   const basicURLsRE = /^\/songs\/add/;
   const adminURLsRE = /^\/update/;
 
-  // if requestURL is not inside publicURLs (therefore a private URL) then run following code
+  // // if requestURL is not inside publicURLs (therefore a private URL) then run following code
   if (basicURLsRE.test(requestURL) || adminURLsRE.test(requestURL)) {
-    // get authorization part of header
-    const authorisationHeader = req.headers.authorization;
-
-    // checks if authorisationHeader is not empty i.e undefined
-    if (authorisationHeader !== undefined) {
+    //   // get authorization part of header
+    if (req.headers.authorization !== null) {
+      const authorisationHeader = req.headers.authorization;
       console.log(authorisationHeader);
       // remove Bearer to only get the JWT
       const maciToken = authorisationHeader.replace("Bearer ", "");
-      // verify the token was created with maci secret
       // removed error check as causing issues. need to revisit and show error when cant verify token
+      // verify the token was created with maci secret
       const decode = jwt.verify(maciToken, process.env.JWT_SECRET);
       console.log(decode);
       const user_role = decode.role;
       console.log(user_role);
-
-      if (user_role === "admin") {
+      if (basicURLsRE.test(requestURL)) {
         next();
       }
-
-      if (user_role === "basic" && basicURLsRE.test(requestURL)) {
-        next();
-      } else {
-        res.send("you are not authorised");
+      if (adminURLsRE.test(requestURL)) {
+        if (user_role === "admin") {
+          next();
+        } else {
+          res.send({ message: "you are not authorised" });
+        }
       }
     } else {
-      res.send("no header");
+      res.send({ message: "no header" });
     }
   } else {
     next();

--- a/server/modules/authorisation/verifyMaciToken.js
+++ b/server/modules/authorisation/verifyMaciToken.js
@@ -21,13 +21,13 @@ function verifyMaciToken(req, res, next) {
         // verify the token was created with maci secret
         const decode = jwt.verify(maciToken, process.env.JWT_SECRET);
         console.log(decode);
-        const user_role = decode.role;
-        console.log(user_role);
+        const userRole = decode.role;
+        console.log(userRole);
         if (basicURLsRE.test(requestURL)) {
           next();
         }
         if (adminURLsRE.test(requestURL)) {
-          if (user_role === "admin") {
+          if (userRole === "admin") {
             next();
           } else {
             res.send({ message: "you are not authorised" });

--- a/server/modules/authorisation/verifyMaciToken.js
+++ b/server/modules/authorisation/verifyMaciToken.js
@@ -12,28 +12,30 @@ function verifyMaciToken(req, res, next) {
   if (basicURLsRE.test(requestURL) || adminURLsRE.test(requestURL)) {
     //   // get authorization part of header
     if (req.headers.authorization !== null) {
-      const authorisationHeader = req.headers.authorization;
-      console.log(authorisationHeader);
-      // remove Bearer to only get the JWT
-      const maciToken = authorisationHeader.replace("Bearer ", "");
-      // removed error check as causing issues. need to revisit and show error when cant verify token
-      // verify the token was created with maci secret
-      const decode = jwt.verify(maciToken, process.env.JWT_SECRET);
-      console.log(decode);
-      const user_role = decode.role;
-      console.log(user_role);
-      if (basicURLsRE.test(requestURL)) {
-        next();
-      }
-      if (adminURLsRE.test(requestURL)) {
-        if (user_role === "admin") {
+      if (req.headers.authorization !== undefined) {
+        const authorisationHeader = req.headers.authorization;
+        console.log(`BOOP ${authorisationHeader}`);
+        // remove Bearer to only get the JWT
+        const maciToken = authorisationHeader.replace("Bearer ", "");
+        // removed error check as causing issues. need to revisit and show error when cant verify token
+        // verify the token was created with maci secret
+        const decode = jwt.verify(maciToken, process.env.JWT_SECRET);
+        console.log(decode);
+        const user_role = decode.role;
+        console.log(user_role);
+        if (basicURLsRE.test(requestURL)) {
           next();
-        } else {
-          res.send({ message: "you are not authorised" });
         }
+        if (adminURLsRE.test(requestURL)) {
+          if (user_role === "admin") {
+            next();
+          } else {
+            res.send({ message: "you are not authorised" });
+          }
+        }
+      } else {
+        res.send({ message: "no header" });
       }
-    } else {
-      res.send({ message: "no header" });
     }
   } else {
     next();


### PR DESCRIPTION
Logic

- checks if endpoint called is a basic or admin set endpoint. if true run the following, else pass user to endpoint
- check if authorisation header exists, if true run following, else pass error stating "no header"
- check role from JWT
    - check if endpoint is basic. If true pass user to endpoint
    - check if endpoint is admin and check if role is admin. if true pass user to endpoint